### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/appknox.yml
+++ b/.github/workflows/appknox.yml
@@ -21,6 +21,10 @@
 
 name: Appknox
 
+permissions:
+  contents: read
+  security-events: write
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/Git-Hub-Chris/GitHub-Copilot/security/code-scanning/1](https://github.com/Git-Hub-Chris/GitHub-Copilot/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow to define the minimal permissions required. Based on the workflow's steps:
1. The `actions/checkout@v4` step requires `contents: read` to check out the repository code.
2. The `github/codeql-action/upload-sarif@v3` step requires `security-events: write` to upload SARIF files to GitHub Advanced Security.

We will add these permissions to the workflow to ensure it operates securely.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
